### PR TITLE
feat(config): make sighting source field configurable

### DIFF
--- a/mispsight/conf_sample.py
+++ b/mispsight/conf_sample.py
@@ -11,3 +11,8 @@ heartbeat_enabled = True
 valkey_host = "127.0.0.1"
 valkey_port = 10002
 expiration_period = 18000
+
+# Optional: customize how a Sighting's "source" field is constructed
+# Defaults: "MISP/<event_uuid>"
+#source_prefix = "MISP"
+#source_attribute = "event_uuid"

--- a/mispsight/config.py
+++ b/mispsight/config.py
@@ -38,7 +38,16 @@ misp_verifycert = conf.misp_verifycert
 vulnerability_lookup_base_url = conf.vulnerability_lookup_base_url
 vulnerability_auth_token = conf.vulnerability_auth_token
 
+try:
+    source_prefix = conf.source_prefix
+except AttributeError:
+    source_prefix = "MISP"
 
+try:
+    source_attribute = conf.source_attribute
+except AttributeError:
+    source_attribute = "event_uuid"
+    
 try:
     heartbeat_enabled = True
     valkey_host = conf.valkey_host

--- a/mispsight/publish.py
+++ b/mispsight/publish.py
@@ -36,10 +36,20 @@ def push_sighting_to_vulnerability_lookup(attribute, vulnerability_ids):
             )
             continue
 
+        # Determine source string dynamically
+        attr_name = getattr(config, "source_attribute", "event_uuid")
+        attr_value = getattr(attribute, attr_name, None)
+
+        if not attr_value:
+            # Fallback if attribute doesn’t exist
+            attr_value = getattr(attribute, "event_uuid", "unknown")
+
+        source_prefix = getattr(config, "source_prefix", "MISP")
+
         # Create the sighting
         sighting = {
             "type": "seen",
-            "source": f"MISP/{attribute.event_uuid}",
+            "source": f"{source_prefix}/{attr_value}",
             "vulnerability": vuln,
             "creation_timestamp": creation_timestamp,
         }


### PR DESCRIPTION
issue: #4 

Add two new optional configuration values to support multi-instance deployments:

- `source_prefix` (default: "MISP")
- `source_attribute` (default: "event_uuid")

The sighting `source` is now built dynamically as:

    f"{source_prefix}/{attribute.<source_attribute>}"

If the configured attribute is missing, the code falls back to `event_uuid`.

This preserves existing behaviour by default while allowing per-instance configuration (e.g. "MISP-Paris/event_id", "MISP-Lyon/orgc_id"), making it easier to distinguish sightings originating from different MISP servers.